### PR TITLE
Update hubot-aotw to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "description": "A simple helpful robot for your Company",
   "dependencies": {
     "hubot": "^2.11.0",
-    "hubot-aotw": "^1.1.0",
+    "hubot-aotw": "^1.2.1",
     "hubot-diagnostics": "0.0.1",
     "hubot-google-images": "^0.1.2",
     "hubot-google-translate": "^0.1.0",


### PR DESCRIPTION
Prevent the use of older versions of the package. Might require `npm update`.

v1.2.1 includes debugging tools and an updater.
