### PR TITLE
fix OU time response formatting and edge cases

### DIFF
--- a/scripts/responses.coffee
+++ b/scripts/responses.coffee
@@ -170,8 +170,13 @@ module.exports = (robot) ->
       msg.send "same"
 
     if Math.floor(Math.random() * 2000) == selector
-      now = new Date
-      hour = (now.getHours() - 1) % 12 # decremented because hubot is in eastern time zone
-      minute = now.getMinutes()
-
-      msg.send "it's " + hour + ":" + minute + " and OU still sucks"
+      now = new Date()
+      # decremented because hubot is in eastern time zone
+      now.setHours((now.getHours() - 1) % 24)
+      hours = now.getHours() % 12
+      if hours == 0
+        hours = 12
+      minutes = now.getMinutes()
+      if minutes < 10
+        minutes = "0" + minutes
+      msg.send "It's " + hours + ":" + minutes + " and OU still sucks"


### PR DESCRIPTION
Fixes Issues:
- hour would render between 0 - 23.
- minutes < 10 would render with only 1 character: https://www.dropbox.com/s/qe4jhv9ny7jaagm/Screenshot%202016-03-20%2009.47.44.png?dl=0
- Capitalization of `It's`

Yes, setHour() correctly handles subtracting over the date boundary...

Probably fixes #93 
