### PR TITLE
Added runner script for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ node_modules
 
 *.rdb
 config.sh
+
+lanbot.log
+lanbot.pid

--- a/bin/hubot-local
+++ b/bin/hubot-local
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -e
+
+npm install
+export PATH="node_modules/.bin:node_modules/hubot/node_modules/.bin:$PATH"
+
+exec node_modules/.bin/hubot "$@"


### PR DESCRIPTION
The current runner script doesn't allow for local development by providing a command line interface for the bot. `hubot-local` addresses this without affecting the behavior of the deployed bot.
