### PR TITLE
Stop Kanye response upon Kanye emoji

### DIFF
--- a/scripts/responses.coffee
+++ b/scripts/responses.coffee
@@ -124,7 +124,7 @@ module.exports = (robot) ->
     else
       @count = 0
 
-  robot.hear /kanye/i, (msg) ->
+  robot.hear /[^:]kanye[^:]/i, (msg) ->
     msg.send ":yeezus:"
 
   robot.hear /\byc/i, (msg) ->


### PR DESCRIPTION
Currently, LANBot responds with the :kanye: emoji upon hearing "kanye", even when embedded in emoji.

This PR stops that behavior.
