### PR TITLE
Stop Kanye response upon Kanye emoji

### DIFF
--- a/scripts/responses.coffee
+++ b/scripts/responses.coffee
@@ -124,7 +124,7 @@ module.exports = (robot) ->
     else
       @count = 0
 
-  robot.hear /kanye/i, (msg) ->
+  robot.hear /^\s*kanye\s*$/i, (msg) ->
     msg.send ":yeezus:"
 
   robot.hear /\byc/i, (msg) ->


### PR DESCRIPTION
Reverts to the commit prior to my previously merged PR and correctly fixes the Kanye regex.

This _actually_ prevents LANBot from responding to the Kanye emoji with Kanye.
