### PR TITLE
Perform censor checks before anything is processed

### DIFF
--- a/scripts/censor.coffee
+++ b/scripts/censor.coffee
@@ -63,5 +63,11 @@ module.exports = (robot) ->
       str.indexOf("@everyone") == -1
 
   robot.responseMiddleware (context, next, done) ->
+    # Final check before sending out any message
     return unless isValid(context.strings) && !responses.isMuted context.response.message
+    next()
+
+  robot.listenerMiddleware (context, next, done) ->
+    # Check if command is valid before processing
+    return unless isValid(context.response.message.text)
     next()


### PR DESCRIPTION
Channel-wide notifications are still slipping through the filter, so this attempts to correct that issue.
